### PR TITLE
test: add IFC→Modelica tests against public sample corpora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Externally-downloaded IFC samples (populated by tests/test_external_ifc.py)
+tests/models/external/

--- a/ifctrano/construction.py
+++ b/ifctrano/construction.py
@@ -150,12 +150,22 @@ class Layers(BaseModel):
     ) -> "Layers":
         layers = []
         for layer in ifc_material_layers:
+            if layer.Material is None:
+                logger.warning(
+                    f"IfcMaterialLayer {layer.id()} has no associated material; "
+                    f"falling back to default material."
+                )
+                material = Material.model_validate(
+                    {"name": f"default_material_{layer.id()}", **DEFAULT_MATERIAL}
+                )
+            else:
+                material = materials.get_material(layer.Material.id())
             thickness = layer.LayerThickness * unit_factor
             layers.append(
                 LayerId(
                     id=layer.id(),
                     thickness=thickness,
-                    material=materials.get_material(layer.Material.id()),
+                    material=material,
                 )
             )
         return cls(layers=layers)

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,3 +1,4 @@
+import ifcopenshell
 from ifcopenshell import file
 
 from ifctrano.construction import Materials, Layers, Constructions
@@ -56,3 +57,25 @@ def test_construction_example_hom(example_hom: file) -> None:
     for wall in get_building_elements(example_hom):
         construction = constructions.get_construction(wall)
         assert construction.layers
+
+
+def test_layers_from_ifc_handles_optional_material() -> None:
+    """``IfcMaterialLayer.Material`` is OPTIONAL per the IFC schema. The
+    parser must fall back to a default material instead of crashing."""
+    ifc_file = ifcopenshell.file(schema="IFC4")
+    real_material = ifc_file.create_entity("IfcMaterial", Name="Concrete")
+    layer_with_material = ifc_file.create_entity(
+        "IfcMaterialLayer", Material=real_material, LayerThickness=0.2
+    )
+    layer_without_material = ifc_file.create_entity(
+        "IfcMaterialLayer", Material=None, LayerThickness=0.1
+    )
+
+    materials = Materials.from_ifc_materials([real_material])
+    layers = Layers.from_ifc_material_layers(
+        [layer_with_material, layer_without_material], materials
+    )
+
+    assert len(layers.layers) == 2
+    assert layers.layers[0].material.name.lower() == "concrete"
+    assert layers.layers[1].material.name.startswith("default_material_")

--- a/tests/test_external_ifc.py
+++ b/tests/test_external_ifc.py
@@ -1,0 +1,171 @@
+"""Integration tests against publicly available IFC sample files.
+
+Each test downloads a small IFC sample from a well-known open-source IFC
+sample collection (cached locally in ``tests/models/external``) and verifies
+that ``ifctrano`` can convert it into a Modelica model via ``trano``.
+
+The samples are sourced from:
+
+* ``youshengCode/IfcSampleFiles`` - vendor-neutral and Autodesk Revit exports
+  routinely used as IFC test corpora.
+* ``andrewisen/bim-whale-ifc-samples`` - synthetic IFC fixtures designed to
+  be small, easy to parse, and freely redistributable (MIT licence).
+
+All sample files are plain ISO 10303-21 STEP text (``ISO-10303-21;`` magic
+header), so there is no executable content; they are safe to download into
+the workspace.
+
+Samples that surface a known unfixed upstream issue are intentionally
+omitted from this suite and tracked separately - see ifctrano#14
+(AdvancedProject.ifc: ``InvalidBuildingStructureError`` on windows without a
+matching host wall).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from ifctrano.building import Building
+from ifctrano.exceptions import NoIfcSpaceFoundError
+
+EXTERNAL_DIR = Path(__file__).parent / "models" / "external"
+DOWNLOAD_TIMEOUT_SECS = 60
+
+
+@dataclass(frozen=True)
+class IfcSample:
+    """A downloadable IFC sample used as a test fixture."""
+
+    name: str
+    url: str
+    description: str
+
+
+# Samples that should successfully convert into a Modelica model.
+PASSING_SAMPLES: list[IfcSample] = [
+    IfcSample(
+        name="Ifc2x3_Duplex_Architecture.ifc",
+        url=(
+            "https://raw.githubusercontent.com/youshengCode/IfcSampleFiles/"
+            "main/Ifc2x3_Duplex_Architecture.ifc"
+        ),
+        description=(
+            "Autodesk Revit Architecture 2011 IFC2x3 duplex apartment, "
+            "21 IfcSpace zones."
+        ),
+    ),
+    IfcSample(
+        name="Ifc4_SampleHouse.ifc",
+        url=(
+            "https://raw.githubusercontent.com/youshengCode/IfcSampleFiles/"
+            "main/Ifc4_SampleHouse.ifc"
+        ),
+        description="Vendor-neutral IFC4 sample house with 4 IfcSpace zones.",
+    ),
+    IfcSample(
+        name="TallBuilding.ifc",
+        url=(
+            "https://raw.githubusercontent.com/andrewisen/bim-whale-ifc-samples/"
+            "main/TallBuilding/IFC/TallBuilding.ifc"
+        ),
+        description=(
+            "Synthetic IFC2x3 tall building with 3 stacked IfcSpace zones, "
+            "from the BIM Whale sample collection."
+        ),
+    ),
+]
+
+
+# Samples that legitimately have no IfcSpace and must raise
+# ``NoIfcSpaceFoundError``. They guard against silent regressions in
+# input validation.
+NO_SPACE_SAMPLES: list[IfcSample] = [
+    IfcSample(
+        name="Ifc4_BasinFacetedBrep.ifc",
+        url=(
+            "https://raw.githubusercontent.com/youshengCode/IfcSampleFiles/"
+            "main/Ifc4_BasinFacetedBrep.ifc"
+        ),
+        description="Single basin geometry, no IfcSpace.",
+    ),
+    IfcSample(
+        name="Ifc4_CubeAdvancedBrep.ifc",
+        url=(
+            "https://raw.githubusercontent.com/youshengCode/IfcSampleFiles/"
+            "main/Ifc4_CubeAdvancedBrep.ifc"
+        ),
+        description="Single cube advanced BRep, no IfcSpace.",
+    ),
+    # Regression test for a bug discovered while curating these tests:
+    # IfcMaterialLayer.Material is OPTIONAL per the IFC schema, but
+    # ``Constructions.from_ifc`` previously crashed with
+    # ``AttributeError: 'NoneType' object has no attribute 'id'`` whenever a
+    # layer had no associated material. ``ifctrano/construction.py`` now
+    # falls back to a default material in that case, so loading this file
+    # gets past construction parsing and fails (as it should) on the
+    # missing IfcSpace.
+    IfcSample(
+        name="Ifc4_WallElementedCase.ifc",
+        url=(
+            "https://raw.githubusercontent.com/youshengCode/IfcSampleFiles/"
+            "main/Ifc4_WallElementedCase.ifc"
+        ),
+        description=(
+            "Elemented wall with IfcMaterialLayer entries whose Material "
+            "attribute is NULL (IFC schema permits this). Regression test "
+            "for the construction-parsing crash on optional materials."
+        ),
+    ),
+]
+
+
+def _download_sample(sample: IfcSample) -> Path:
+    EXTERNAL_DIR.mkdir(parents=True, exist_ok=True)
+    dest = EXTERNAL_DIR / sample.name
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - https URL from sample list
+            sample.url, timeout=DOWNLOAD_TIMEOUT_SECS
+        ) as response:
+            payload = response.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        pytest.skip(f"Could not download {sample.url}: {exc}")
+    if not payload.startswith(b"ISO-10303-21"):
+        pytest.skip(
+            f"Downloaded {sample.url} is not a valid IFC STEP file "
+            f"(unexpected header)."
+        )
+    dest.write_bytes(payload)
+    return dest
+
+
+@pytest.fixture(scope="session")
+def external_ifc_dir() -> Path:
+    EXTERNAL_DIR.mkdir(parents=True, exist_ok=True)
+    return EXTERNAL_DIR
+
+
+@pytest.mark.parametrize("sample", PASSING_SAMPLES, ids=lambda s: s.name)
+def test_external_ifc_to_modelica(sample: IfcSample) -> None:
+    """Each sample with at least one IfcSpace must produce a Modelica model."""
+    ifc_path = _download_sample(sample)
+    building = Building.from_ifc(ifc_path)
+    model = building.get_model()
+    assert model, f"Empty Modelica model for {sample.name}"
+    assert building.space_boundaries, (
+        f"No space boundaries detected in {sample.name}"
+    )
+
+
+@pytest.mark.parametrize("sample", NO_SPACE_SAMPLES, ids=lambda s: s.name)
+def test_external_ifc_without_spaces_raises(sample: IfcSample) -> None:
+    """Files without any IfcSpace must surface ``NoIfcSpaceFoundError``."""
+    ifc_path = _download_sample(sample)
+    with pytest.raises(NoIfcSpaceFoundError):
+        Building.from_ifc(ifc_path)


### PR DESCRIPTION
Adds tests/test_external_ifc.py covering six public IFC samples
downloaded from youshengCode/IfcSampleFiles and andrewisen/bim-whale-
ifc-samples (cached under tests/models/external/, gitignored): three
"happy path" Modelica conversions and three IfcSpace-less files that
must surface NoIfcSpaceFoundError.

While curating the corpus, Ifc4_WallElementedCase.ifc revealed a crash
in Layers.from_ifc_material_layers when an IfcMaterialLayer has no
associated material — a configuration the IFC schema explicitly
allows. construction.py now logs the missing-material case and falls
back to a default material; tests/test_construction.py adds a unit
test pinning the new behaviour.

A second sample, AdvancedProject.ifc, fails downstream with
InvalidBuildingStructureError ("window without matching wall"); it is
intentionally omitted from the suite and tracked in andoludo/ifctrano#14.